### PR TITLE
Fix for optional js extension support

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -63,7 +63,7 @@ export const writeImportsForModel = (
 		if (filteredFields.length > 0) {
 			importList.push({
 				kind: StructureKind.ImportDeclaration,
-				moduleSpecifier: './index',
+				moduleSpecifier: `./index${jsExt(config)}`,
 				namedImports: Array.from(
 					new Set(
 						filteredFields.flatMap((f) => [
@@ -242,9 +242,9 @@ export const populateModelFile = (
 export const generateBarrelFile = (models: DMMF.Model[], indexFile: SourceFile, config: Config) => {
 	models.forEach((model) =>
 		indexFile.addExportDeclaration({
-			moduleSpecifier: `./${model.name.toLowerCase()}${
-				config.includeJSExtension ? '.js' : ''
-			}`,
+			moduleSpecifier: `./${model.name.toLowerCase()}${jsExt(config)}`
 		})
 	)
 }
+
+const jsExt = (config: Config) => config.includeJSExtension ? '.js' : ''


### PR DESCRIPTION
Hi @IgnusG ,
I started to use your zod-prisma PR ([#128](https://github.com/CarterGrimmeisen/zod-prisma/pull/128)). This adds another commit to this PR to also fix reverse imports of `index.js` in the generated model files. Feel free to merge into your branch and the #128 PR.
FYI, I republished the module with this change to NPM under `@frando/zod-prisma` because it's so damn inconvenient to use git dependencies of TypeScript modules in a Node.js setup. Hope the PR gets merged soon to not have to do this anymore :)
Thanks,
Frando